### PR TITLE
Feat/refactor owner sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "r": "NODE_ENV=development tsx -r dotenv/config",
     "rt": "LOG_LEVEL=trace NODE_ENV=development tsx",
     "typecheck": "tsc --noEmit",
-    "generate:openapi": "pnpm openapi -i ./static/openapi.json -c axios -o src/ordinals-api/client --useOptions --name Ordinals --useUnionTypes"
+    "generate:openapi": "pnpm openapi -i https://ordinals-api.vercel.app/openapi.yaml -c axios -o src/ordinals-api/client --useOptions --name Ordinals --useUnionTypes"
   },
   "keywords": [],
   "license": "ISC",

--- a/scripts/test-filter.ts
+++ b/scripts/test-filter.ts
@@ -12,7 +12,12 @@ async function run() {
   const filtered = await fetchAndFilterInscriptions(index - 1);
   // const list = await fetchOrdinals(index - 1);
   // const filtered = await filterInscriptions(list);
-  console.log(filtered.inscriptions.map((i) => i._name));
+  const name = filtered.inscriptions.slice(0, 1).map((i) => i._name)[0];
+  console.log("name", name);
+  if (name) {
+    console.log(encodeURIComponent(name));
+  }
+  // console.log(filtered.inscriptions.slice(0, 1).map((i) => i._name));
   console.log("max ID:", filtered.maxId);
 }
 

--- a/src/ordinals-api/client/Ordinals.ts
+++ b/src/ordinals-api/client/Ordinals.ts
@@ -22,7 +22,7 @@ export class Ordinals {
     constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
         this.request = new HttpRequest({
             BASE: config?.BASE ?? 'https://api.hiro.so',
-            VERSION: config?.VERSION ?? '0.0.1',
+            VERSION: config?.VERSION ?? '0.1.2',
             WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
             CREDENTIALS: config?.CREDENTIALS ?? 'include',
             TOKEN: config?.TOKEN,

--- a/src/ordinals-api/client/core/OpenAPI.ts
+++ b/src/ordinals-api/client/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: 'https://api.hiro.so',
-    VERSION: '0.0.1',
+    VERSION: '0.1.2',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/src/ordinals-api/client/services/InscriptionsService.ts
+++ b/src/ordinals-api/client/services/InscriptionsService.ts
@@ -1,258 +1,381 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { CancelablePromise } from "../core/CancelablePromise";
-import type { BaseHttpRequest } from "../core/BaseHttpRequest";
+import type { CancelablePromise } from '../core/CancelablePromise';
+import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 
 export class InscriptionsService {
-  constructor(public readonly httpRequest: BaseHttpRequest) {}
 
-  /**
-   * Inscriptions
-   * Retrieves a list of inscriptions with options to filter and sort results
-   * @returns any Default Response
-   * @throws ApiError
-   */
-  public getOrdinalsV1Inscriptions({
-    genesisBlock,
-    fromGenesisBlockHeight,
-    toGenesisBlockHeight,
-    fromGenesisTimestamp,
-    toGenesisTimestamp,
-    fromSatOrdinal,
-    toSatOrdinal,
-    fromSatCoinbaseHeight,
-    toSatCoinbaseHeight,
-    fromNumber,
-    toNumber,
-    id,
-    number,
-    output,
-    address,
-    mimeType,
-    rarity,
-    offset,
-    limit,
-    orderBy,
-    order,
-  }: {
-    /**
-     * Bitcoin block identifier (height or hash)
-     */
-    genesisBlock?: string;
-    /**
-     * Bitcoin block height
-     */
-    fromGenesisBlockHeight?: string;
-    /**
-     * Bitcoin block height
-     */
-    toGenesisBlockHeight?: string;
-    /**
-     * Block UNIX epoch timestamp (milliseconds)
-     */
-    fromGenesisTimestamp?: number;
-    /**
-     * Block UNIX epoch timestamp (milliseconds)
-     */
-    toGenesisTimestamp?: number;
-    /**
-     * Ordinal number that uniquely identifies a satoshi
-     */
-    fromSatOrdinal?: number;
-    /**
-     * Ordinal number that uniquely identifies a satoshi
-     */
-    toSatOrdinal?: number;
-    /**
-     * Bitcoin block height
-     */
-    fromSatCoinbaseHeight?: string;
-    /**
-     * Bitcoin block height
-     */
-    toSatCoinbaseHeight?: string;
-    /**
-     * Inscription number
-     */
-    fromNumber?: number;
-    /**
-     * Inscription number
-     */
-    toNumber?: number;
-    /**
-     * Array of inscription IDs
-     */
-    id?: Array<string>;
-    /**
-     * Array of inscription numbers
-     */
-    number?: Array<number>;
-    /**
-     * An UTXO for a Bitcoin transaction
-     */
-    output?: string;
-    /**
-     * Array of Bitcoin addresses
-     */
-    address?: Array<string>;
-    /**
-     * Array of inscription MIME types
-     */
-    mimeType?: Array<string>;
-    /**
-     * Array of satoshi rarity values
-     */
-    rarity?: Array<
-      "common" | "uncommon" | "rare" | "epic" | "legendary" | "mythic"
-    >;
-    /**
-     * Result offset
-     */
-    offset?: number;
-    /**
-     * Results per page
-     */
-    limit?: number;
-    /**
-     * Parameter to order results by
-     */
-    orderBy?: "genesis_block_height" | "ordinal" | "rarity";
-    /**
-     * Results order
-     */
-    order?: "asc" | "desc";
-  }): CancelablePromise<{
-    limit: number;
-    offset: number;
-    total: number;
-    results: Array<{
-      id: string;
-      number: number;
-      address: string;
-      genesis_address: string;
-      genesis_block_height: number;
-      genesis_block_hash: string;
-      genesis_tx_id: string;
-      genesis_fee: string;
-      genesis_timestamp: number;
-      tx_id: string;
-      location: string;
-      output: string;
-      value: string;
-      offset: string;
-      sat_ordinal: string;
-      sat_rarity: string;
-      sat_coinbase_height: number;
-      mime_type: string;
-      content_type: string;
-      content_length: number;
-      timestamp: number;
-    }>;
-  }> {
-    return this.httpRequest.request({
-      method: "GET",
-      url: "/ordinals/v1/inscriptions",
-      query: {
-        genesis_block: genesisBlock,
-        from_genesis_block_height: fromGenesisBlockHeight,
-        to_genesis_block_height: toGenesisBlockHeight,
-        from_genesis_timestamp: fromGenesisTimestamp,
-        to_genesis_timestamp: toGenesisTimestamp,
-        from_sat_ordinal: fromSatOrdinal,
-        to_sat_ordinal: toSatOrdinal,
-        from_sat_coinbase_height: fromSatCoinbaseHeight,
-        to_sat_coinbase_height: toSatCoinbaseHeight,
-        from_number: fromNumber,
-        to_number: toNumber,
-        id: id,
-        number: number,
-        output: output,
-        address: address,
-        mime_type: mimeType,
-        rarity: rarity,
-        offset: offset,
-        limit: limit,
-        order_by: orderBy,
-        order: order,
-      },
-      errors: {
-        404: `Default Response`,
-      },
-    });
-  }
+    constructor(public readonly httpRequest: BaseHttpRequest) {}
 
-  /**
-   * Inscription
-   * Retrieves a single inscription
-   * @returns any Default Response
-   * @throws ApiError
-   */
-  public getOrdinalsV1Inscriptions1({
-    id,
-  }: {
     /**
-     * Inscription unique identifier (number or ID)
+     * Inscriptions
+     * Retrieves a list of inscriptions with options to filter and sort results
+     * @returns any Default Response
+     * @throws ApiError
      */
-    id: string | number;
-  }): CancelablePromise<{
-    id: string;
-    number: number;
-    address: string;
-    genesis_address: string;
-    genesis_block_height: number;
-    genesis_block_hash: string;
-    genesis_tx_id: string;
-    genesis_fee: string;
-    genesis_timestamp: number;
-    tx_id: string;
-    location: string;
-    output: string;
-    value: string;
-    offset: string;
-    sat_ordinal: string;
-    sat_rarity: string;
-    sat_coinbase_height: number;
-    mime_type: string;
-    content_type: string;
-    content_length: number;
-    timestamp: number;
-  }> {
-    return this.httpRequest.request({
-      method: "GET",
-      url: "/ordinals/v1/inscriptions/{id}",
-      path: {
-        id: id,
-      },
-      errors: {
-        404: `Default Response`,
-      },
-    });
-  }
+    public getInscriptions({
+        genesisBlock,
+        fromGenesisBlockHeight,
+        toGenesisBlockHeight,
+        fromGenesisTimestamp,
+        toGenesisTimestamp,
+        fromSatOrdinal,
+        toSatOrdinal,
+        fromSatCoinbaseHeight,
+        toSatCoinbaseHeight,
+        fromNumber,
+        toNumber,
+        id,
+        number,
+        output,
+        address,
+        mimeType,
+        rarity,
+        offset,
+        limit,
+        orderBy,
+        order,
+    }: {
+        /**
+         * Bitcoin block identifier (height or hash)
+         */
+        genesisBlock?: string,
+        /**
+         * Bitcoin block height
+         */
+        fromGenesisBlockHeight?: string,
+        /**
+         * Bitcoin block height
+         */
+        toGenesisBlockHeight?: string,
+        /**
+         * Block UNIX epoch timestamp (milliseconds)
+         */
+        fromGenesisTimestamp?: number,
+        /**
+         * Block UNIX epoch timestamp (milliseconds)
+         */
+        toGenesisTimestamp?: number,
+        /**
+         * Ordinal number that uniquely identifies a satoshi
+         */
+        fromSatOrdinal?: number,
+        /**
+         * Ordinal number that uniquely identifies a satoshi
+         */
+        toSatOrdinal?: number,
+        /**
+         * Bitcoin block height
+         */
+        fromSatCoinbaseHeight?: string,
+        /**
+         * Bitcoin block height
+         */
+        toSatCoinbaseHeight?: string,
+        /**
+         * Inscription number
+         */
+        fromNumber?: number,
+        /**
+         * Inscription number
+         */
+        toNumber?: number,
+        /**
+         * Array of inscription IDs
+         */
+        id?: Array<string>,
+        /**
+         * Array of inscription numbers
+         */
+        number?: Array<number>,
+        /**
+         * An UTXO for a Bitcoin transaction
+         */
+        output?: string,
+        /**
+         * Array of Bitcoin addresses
+         */
+        address?: Array<string>,
+        /**
+         * Array of inscription MIME types
+         */
+        mimeType?: Array<string>,
+        /**
+         * Array of satoshi rarity values
+         */
+        rarity?: Array<('common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'mythic')>,
+        /**
+         * Result offset
+         */
+        offset?: number,
+        /**
+         * Results per page
+         */
+        limit?: number,
+        /**
+         * Parameter to order results by
+         */
+        orderBy?: ('genesis_block_height' | 'ordinal' | 'rarity'),
+        /**
+         * Results order
+         */
+        order?: ('asc' | 'desc'),
+    }): CancelablePromise<{
+        limit: number;
+        offset: number;
+        total: number;
+        results: Array<{
+            id: string;
+            number: number;
+            address: (string | null);
+            genesis_address: string;
+            genesis_block_height: number;
+            genesis_block_hash: string;
+            genesis_tx_id: string;
+            genesis_fee: string;
+            genesis_timestamp: number;
+            tx_id: string;
+            location: string;
+            output: string;
+            value: (string | null);
+            offset: (string | null);
+            sat_ordinal: string;
+            sat_rarity: string;
+            sat_coinbase_height: number;
+            mime_type: string;
+            content_type: string;
+            content_length: number;
+            timestamp: number;
+        }>;
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/ordinals/v1/inscriptions',
+            query: {
+                'genesis_block': genesisBlock,
+                'from_genesis_block_height': fromGenesisBlockHeight,
+                'to_genesis_block_height': toGenesisBlockHeight,
+                'from_genesis_timestamp': fromGenesisTimestamp,
+                'to_genesis_timestamp': toGenesisTimestamp,
+                'from_sat_ordinal': fromSatOrdinal,
+                'to_sat_ordinal': toSatOrdinal,
+                'from_sat_coinbase_height': fromSatCoinbaseHeight,
+                'to_sat_coinbase_height': toSatCoinbaseHeight,
+                'from_number': fromNumber,
+                'to_number': toNumber,
+                'id': id,
+                'number': number,
+                'output': output,
+                'address': address,
+                'mime_type': mimeType,
+                'rarity': rarity,
+                'offset': offset,
+                'limit': limit,
+                'order_by': orderBy,
+                'order': order,
+            },
+            errors: {
+                404: `Default Response`,
+            },
+        });
+    }
 
-  /**
-   * Inscription content
-   * Retrieves the contents of a single inscription
-   * @returns any Default Response
-   * @throws ApiError
-   */
-  public getOrdinalsV1InscriptionsContent({
-    id,
-  }: {
     /**
-     * Inscription unique identifier (number or ID)
+     * Transfers per block
+     * Retrieves a list of inscription transfers that ocurred at a specific Bitcoin block
+     * @returns any Default Response
+     * @throws ApiError
      */
-    id: string | number;
-  }): CancelablePromise<any> {
-    return this.httpRequest.request({
-      method: "GET",
-      url: "/ordinals/v1/inscriptions/{id}/content",
-      path: {
-        id: id,
-      },
-      errors: {
-        404: `Default Response`,
-      },
-    });
-  }
+    public getTransfersPerBlock({
+        block,
+        offset,
+        limit,
+    }: {
+        /**
+         * Bitcoin block identifier (height or hash)
+         */
+        block: string,
+        /**
+         * Result offset
+         */
+        offset?: number,
+        /**
+         * Results per page
+         */
+        limit?: number,
+    }): CancelablePromise<{
+        limit: number;
+        offset: number;
+        total: number;
+        results: Array<{
+            id: string;
+            number: number;
+            from: {
+                block_height: number;
+                block_hash: string;
+                address: (string | null);
+                tx_id: string;
+                location: string;
+                output: string;
+                value: (string | null);
+                offset: (string | null);
+                timestamp: number;
+            };
+            to: {
+                block_height: number;
+                block_hash: string;
+                address: (string | null);
+                tx_id: string;
+                location: string;
+                output: string;
+                value: (string | null);
+                offset: (string | null);
+                timestamp: number;
+            };
+        }>;
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/ordinals/v1/inscriptions/transfers',
+            query: {
+                'block': block,
+                'offset': offset,
+                'limit': limit,
+            },
+            errors: {
+                404: `Default Response`,
+            },
+        });
+    }
+
+    /**
+     * Inscription
+     * Retrieves a single inscription
+     * @returns any Default Response
+     * @throws ApiError
+     */
+    public getInscription({
+        id,
+    }: {
+        /**
+         * Inscription unique identifier (number or ID)
+         */
+        id: (string | number),
+    }): CancelablePromise<{
+        id: string;
+        number: number;
+        address: (string | null);
+        genesis_address: string;
+        genesis_block_height: number;
+        genesis_block_hash: string;
+        genesis_tx_id: string;
+        genesis_fee: string;
+        genesis_timestamp: number;
+        tx_id: string;
+        location: string;
+        output: string;
+        value: (string | null);
+        offset: (string | null);
+        sat_ordinal: string;
+        sat_rarity: string;
+        sat_coinbase_height: number;
+        mime_type: string;
+        content_type: string;
+        content_length: number;
+        timestamp: number;
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/ordinals/v1/inscriptions/{id}',
+            path: {
+                'id': id,
+            },
+            errors: {
+                404: `Default Response`,
+            },
+        });
+    }
+
+    /**
+     * Inscription content
+     * Retrieves the contents of a single inscription
+     * @returns any Default Response
+     * @throws ApiError
+     */
+    public getInscriptionContent({
+        id,
+    }: {
+        /**
+         * Inscription unique identifier (number or ID)
+         */
+        id: (string | number),
+    }): CancelablePromise<any> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/ordinals/v1/inscriptions/{id}/content',
+            path: {
+                'id': id,
+            },
+            errors: {
+                404: `Default Response`,
+            },
+        });
+    }
+
+    /**
+     * Inscription transfers
+     * Retrieves all transfers for a single inscription
+     * @returns any Default Response
+     * @throws ApiError
+     */
+    public getInscriptionTransfers({
+        id,
+        offset,
+        limit,
+    }: {
+        /**
+         * Inscription unique identifier (number or ID)
+         */
+        id: (string | number),
+        /**
+         * Result offset
+         */
+        offset?: number,
+        /**
+         * Results per page
+         */
+        limit?: number,
+    }): CancelablePromise<{
+        limit: number;
+        offset: number;
+        total: number;
+        results: Array<{
+            block_height: number;
+            block_hash: string;
+            address: (string | null);
+            tx_id: string;
+            location: string;
+            output: string;
+            value: (string | null);
+            offset: (string | null);
+            timestamp: number;
+        }>;
+    }> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/ordinals/v1/inscriptions/{id}/transfers',
+            path: {
+                'id': id,
+            },
+            query: {
+                'offset': offset,
+                'limit': limit,
+            },
+            errors: {
+                404: `Default Response`,
+            },
+        });
+    }
+
 }

--- a/src/ordinals-api/client/services/SatoshisService.ts
+++ b/src/ordinals-api/client/services/SatoshisService.ts
@@ -14,7 +14,7 @@ export class SatoshisService {
      * @returns any Default Response
      * @throws ApiError
      */
-    public getOrdinalsV1Sats({
+    public getSatoshi({
         ordinal,
     }: {
         /**

--- a/src/ordinals-api/client/services/StatusService.ts
+++ b/src/ordinals-api/client/services/StatusService.ts
@@ -14,7 +14,7 @@ export class StatusService {
      * @returns any Default Response
      * @throws ApiError
      */
-    public getOrdinalsV1(): CancelablePromise<{
+    public getApiStatus(): CancelablePromise<{
         server_version: string;
         status: string;
         block_height?: number;

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,7 +1,12 @@
 import { Prisma } from "@prisma/client";
 import { InscriptionContent } from "../validator";
+import { OWNERS_SYNC_ID } from "./owners";
 
+// can never be equal to OWNER_SYNC_VERSION
 export const SYNC_VERSION = 7;
+if (Number(SYNC_VERSION) === OWNERS_SYNC_ID) {
+  throw new Error("SYNC_VERSION cannot be equal to OWNERS_SYNC_ID");
+}
 
 export type WritableInscription = {
   _name: string;


### PR DESCRIPTION
This PR is the start of work to refactor the way owners of Sats names are synced. When a Sats inscription is transferred, we want to update our DB with the current owner.

Previously, the way this worked was to go through every single Sats inscription and fetch the current owner. This has very poor performance, especially as the number of Sats names grows.

This PR users an API endpoint from the Hiro Ordinals API that returns all Inscription transfers within a block. By using this API, the service only needs to update ownership for every new block.

This PR has been lightly tested, but needs further testing before being ready for production.